### PR TITLE
Add temp recepients to import notification email until salesforce is …

### DIFF
--- a/akita/map.jinja
+++ b/akita/map.jinja
@@ -63,7 +63,7 @@
     'mailer_port': '25',
     'salesforce_host': 'login.salesforce.com',
     'salesforce_user': 'akitaintegration@plos.org',
-    'salesforce_import_notify_to': 'edboardmgmt@plos.org',
+    'salesforce_import_notify_to': 'edboardmgmt@plos.org,bmiller@plos.org,mcrystal@plos.org',
     'jwt_public_keys': {
       'aperta': '-----BEGIN PUBLIC KEY-----
         MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEcrZ/0MogfOblkHs0OjZNynOC4AVi


### PR DESCRIPTION
…fixed

This way madison will know who to import manually into Discourse until the email issue in salesforce is fixed.

Rails should split the email addresses out https://guides.rubyonrails.org/action_mailer_basics.html#sending-email-to-multiple-recipients

and you can test it in dev by going to `/rails/mailers/salesforce_import_mailer/preview_import` and changing the `preview_import` method.