### PR TITLE
akita exporter fix

### DIFF
--- a/akita/etc/systemd/system/akita-exporter.service
+++ b/akita/etc/systemd/system/akita-exporter.service
@@ -8,7 +8,7 @@ User=prometheus
 Group=prometheus
 Environment="HOME={{ home }}"
 WorkingDirectory={{ home }}
-ExecStart=/usr/local/bin/ruby-service $HOME %p bundle exec puma -C prometheus-exporter/akita_collector.rb --prefix akita_
+ExecStart=/bin/bash -c '{{ home }}/prometheus-exporter/start-akita-exporter.sh'
 
 [Install]
 WantedBy=multi-user.target

--- a/akita/etc/systemd/system/akita-exporter.service
+++ b/akita/etc/systemd/system/akita-exporter.service
@@ -8,7 +8,7 @@ User=prometheus
 Group=prometheus
 Environment="HOME={{ home }}"
 WorkingDirectory={{ home }}
-ExecStart=/bin/bash -c '{{ home }}/prometheus-exporter/start-akita-exporter.sh'
+ExecStart={{ home }}/prometheus-exporter/start-akita-exporter.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/akita/init.sls
+++ b/akita/init.sls
@@ -1,6 +1,6 @@
 {% set ruby_ver = salt.pillar.get('akita:versions:ruby') %}
 {% from 'lib/auth_keys.sls' import manage_authorized_keys %}
-{% from 'lib/environment.sls' import environment %}
+{% set environment = salt.grains.get('environment') %}
 {% from "akita/map.jinja" import props with context %}
 {% set capdeloy_host = salt['pillar.get']('environment:' ~ environment ~ ':capdeploy', 'None') %}
 {% set fqdn = salt['grains.get']('fqdn', 'localhost.localdomain') -%}

--- a/akita/opt/prometheus/prometheus-exporter/start-akita-exporter.sh
+++ b/akita/opt/prometheus/prometheus-exporter/start-akita-exporter.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+export HOME=/opt/prometheus
+source /opt/prometheus/prometheus-exporter/.prometheus-exporter-rc
+
+if ! gem list prometheus_exporter -i; then
+    cd $HOME && bundle install
+fi
+
+cd $HOME && prometheus_exporter -v -c prometheus-exporter/akita_collector.rb --prefix akita_

--- a/akita/prometheus-exporter.sls
+++ b/akita/prometheus-exporter.sls
@@ -85,6 +85,15 @@ akita-exporter-service:
     - name: akita-exporter
     - enable: True
     - require:
-      - file: /etc/systemd/system/akita-exporter.service
+      - akita-exporter-unit-file
+      - akita-exporter-start-script
+
+akita-exporter-start-script:
+  file.managed:
+    - name: {{ app_home }}/start-akita-exporter.sh
+    - source: salt://akita/{{ app_home }}/start-akita-exporter.sh
+    - user: {{ user }}
+    - group: {{ user }}
+    - mode: 744
 {%- endif %}
 

--- a/akita/prometheus-exporter.sls
+++ b/akita/prometheus-exporter.sls
@@ -94,6 +94,6 @@ akita-exporter-start-script:
     - source: salt://akita/{{ app_home }}/start-akita-exporter.sh
     - user: {{ user }}
     - group: {{ user }}
-    - mode: 744
+    - mode: 755
 {%- endif %}
 


### PR DESCRIPTION
Akita exporter was broken for bionic, and the `init.sls` was still using the `lib/environment.sls` file to get its envrionment which was leaving `undefined` in the consul config file